### PR TITLE
Skip Jenkins when [ci skip] is in commit.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -30,6 +30,7 @@ def get_info_from_commit(commit):
         'diff': diff,
         'files': files,
         'short_commit_msg': short_commit_msg,
+        'full_commit_msg': commit['message'],
         'reply_to': reply_to,
         'sha': commit['id']
     }


### PR DESCRIPTION
This hint can be added automatically in the pre and postrelease commits done by zest.releaser by adding this in your `~/.pypirc`:

```
[zest.releaser]
extra-message =
    [ci skip]
```
This makes sure no mails are sent complaining that a package is not in the checkouts list, which happens because you usually have just taken it out of the checkouts list because you have made a new release. This fixes https://github.com/plone/jenkins.plone.org/issues/128

More importantly, it does not needlessly flood Jenkins when releasing a package.  Currently, when you release a package that is used with the same branch on Plone 4.3. and Plone 5, you get ten Jenkins jobs. You get these five because you have updated the version pin, which is good:

- Plone 4.3 Python 2.6
- Plone 4.3 Python 2.7
- Plone 5
- Plone 5 AT
- Plone 5 Robot

But you get the same five again because of the pre and postrelease commits, even though they have `[ci skip]` in them.

Possibly Jenkins itself can check for the `[ci skip]` hint, but with this pull request we put the burden on mr.roboto, which is what the above linked Jenkins issue suggests.

Note: if there is a Travis job for mr.roboto, it will probably not run on this pull request because of the many mentions of `[ci skip]`. :-)

Also: I have no idea how to test this.