### PR TITLE
Auto checkout

### DIFF
--- a/src/mr.roboto/src/mr/roboto/events.py
+++ b/src/mr.roboto/src/mr/roboto/events.py
@@ -30,3 +30,7 @@ class NewPullRequest(PullRequest):
 
 class UpdatedPullRequest(PullRequest):
     pass
+
+
+class MergedPullRequest(PullRequest):
+    pass

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -45,7 +45,7 @@ IGNORE_NO_AGREEMENT = (
 
 def mail_missing_checkout(mailer, who, repo, branch, pv, email):
     msg = Message(
-        subject='CHECKOUT ERROR {0} {1}'.format(repo, branch),
+        subject='POSSIBLE CHECKOUT ERROR {0} {1}'.format(repo, branch),
         sender='Jenkins Job FAIL <jenkins@plone.org>',
         recipients=[
             'ramon.nb@gmail.com',

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -1,10 +1,15 @@
 # -*- encoding: utf-8 -*-
+from datetime import datetime
+from github import InputGitAuthor
+from github import InputGitTreeElement
 from mr.roboto import templates
 from mr.roboto.events import CommitAndMissingCheckout
+from mr.roboto.events import MergedPullRequest
 from mr.roboto.events import NewCoreDevPush
 from mr.roboto.events import NewPullRequest
 from mr.roboto.events import UpdatedPullRequest
 from mr.roboto.utils import get_info_from_commit
+from mr.roboto.utils import get_pickled_data
 from mr.roboto.utils import plone_versions_targeted
 from mr.roboto.utils import shorten_pull_request_url
 from pyramid.events import subscriber
@@ -123,6 +128,7 @@ class PullRequestSubscriber(object):
         self._repo_full_name = None
         self._g_pull = None
         self._commits_url = None
+        self._target_branch = None
 
         self.run()
 
@@ -176,6 +182,12 @@ class PullRequestSubscriber(object):
         if self._commits_url is None:
             self._commits_url = self.pull_request['commits_url']
         return self._commits_url
+
+    @property
+    def target_branch(self):
+        if self._target_branch is None:
+            self._target_branch = self.pull_request['base']['ref']
+        return self._target_branch
 
     def run(self):
         raise NotImplemented
@@ -398,3 +410,95 @@ class WarnTestsNeedToRun(PullRequestSubscriber):
                 context=self.status_context.format(version),
             )
             self.log('created pending status for plone {0}'.format(version))
+
+
+@subscriber(MergedPullRequest)
+class UpdateCoredevCheckouts(PullRequestSubscriber):
+
+    def run(self):
+        """Add package that got a pull request merged into checkouts.cfg
+
+        - only for packages that are part of Plone coredev.
+        - on all Plone coredev versions that track the branch that was
+        targeted by the pull request
+        """
+        # pull requests on buildout.coredev itself do not need any extra work
+        if self.repo_full_name == 'plone/buildout.coredev':
+            return
+
+        plone_versions = plone_versions_targeted(
+            self.repo_full_name,
+            self.target_branch,
+            self.event.request,
+        )
+        if not plone_versions:
+            msg = 'no plone coredev version tracks branch {0} ' \
+                  'of {1}, checkouts.cfg not updated'
+            self.log(msg.format(self.target_branch, self.repo_name))
+            return
+
+        checkouts = get_pickled_data(
+            self.event.request.registry.settings['checkouts_file']
+        )
+        not_in_checkouts = [
+            version
+            for version in plone_versions
+            if self.repo_name not in checkouts[version]
+        ]
+        if not not_in_checkouts:
+            msg = 'is already on checkouts.cfg of all plone ' \
+                  'versions that it targets {1}'
+            self.log(msg.format(self.short_url, plone_versions))
+            return
+
+        self.add_pacakge_to_checkouts(not_in_checkouts)
+
+    def add_pacakge_to_checkouts(self, versions):
+        """Add package to checkouts.cfg on buildout.coredev plone version"""
+        g_user = self.github.get_user(self.pull_request['user']['login'])
+        user = InputGitAuthor(
+            g_user.author.name,
+            g_user.author.email,
+            datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'),
+        )
+        org = self.github.get_organization('plone')
+        repo = org.get_repo('buildout.coredev')
+        filename = u'checkouts.cfg'
+        for version in versions:
+            head_ref = repo.get_git_ref('heads/{0}'.format(version))
+            checkouts_cfg_file = repo.get_file_contents(
+                'checkouts.cfg',
+                head_ref.object.sha,
+            )
+            line = '    {0}\n'.format(self.repo_name)
+            checkouts_new_data = checkouts_cfg_file.decoded_content + line
+            latest_commit = repo.get_git_commit(head_ref.object.sha)
+            base_tree = latest_commit.tree
+            mode = [
+                t.mode
+                for t in base_tree.tree
+                if t.path == filename
+                ]
+            if mode:
+                mode = mode[0]
+            else:
+                mode = '100644'
+
+            element = InputGitTreeElement(
+                path=filename,
+                mode=mode,
+                type=checkouts_cfg_file.type,
+                content=checkouts_new_data
+            )
+            new_tree = repo.create_git_tree([element], base_tree)
+
+            new_commit = repo.create_git_commit(
+                'Add {0} to checkouts.cfg'.format(self.repo_name),
+                new_tree,
+                [latest_commit, ],
+                user,
+                user,
+            )
+            head_ref.edit(sha=new_commit.sha, force=False)
+            msg = 'add to checkouts.cfg of buildout.coredev {0}'
+            self.log(msg.format(version))

--- a/src/mr.roboto/src/mr/roboto/templates/error_commit_checkout.pt
+++ b/src/mr.roboto/src/mr/roboto/templates/error_commit_checkout.pt
@@ -6,9 +6,14 @@ This package is used by Plone coredev ${pv} branch,
 but it’s not currently checked out so is not including
 your change for testing.
 
-You must add this package at
+If you were merging a pull request,
+worry not mr.roboto took care of it already,
+still double check checkouts.cfg:
 
 https://github.com/plone/buildout.coredev/blob/${pv}/checkouts.cfg
+
+On the other hand, if you made a direct commit to a branch,
+add the package to checkouts.cfg (above link) please.
 
 Regards,
 mr.roboto

--- a/src/mr.roboto/src/mr/roboto/tests/test_add_to_checkouts.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_add_to_checkouts.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+from mr.roboto.events import MergedPullRequest
+from mr.roboto.subscriber import UpdateCoredevCheckouts
+from tempfile import NamedTemporaryFile
+from testfixtures import LogCapture
+
+import copy
+import mock
+import os
+import pickle
+import unittest
+
+
+"""
+Reduced set of data sent by Github about a pull request.
+
+Each payload is adapted later on to test all corner cases.
+"""
+PAYLOAD = {
+    'number': '45',
+    'html_url': 'https://github.com/plone/buildout.coredev/pull/34567',
+    'base': {
+        'repo': {
+            'full_name': 'plone/buildout.coredev',
+            'name': 'buildout.coredev',
+        },
+    },
+    'user': {
+        'login': 'mr.bean',
+    },
+}
+
+NO_PLONE_VERSION_PAYLOAD = copy.deepcopy(PAYLOAD)
+NO_PLONE_VERSION_PAYLOAD['html_url'] = 'https://github.com/plone/plone.uuid/pull/3'  # noqa
+NO_PLONE_VERSION_PAYLOAD['base']['ref'] = 'my-upstream-branch'
+NO_PLONE_VERSION_PAYLOAD['base']['repo']['name'] = 'plone.uuid'
+NO_PLONE_VERSION_PAYLOAD['base']['repo']['full_name'] = 'plone/plone.uuid'
+
+
+PLONE_VERSION_PAYLOAD = copy.deepcopy(NO_PLONE_VERSION_PAYLOAD)
+PLONE_VERSION_PAYLOAD['base']['ref'] = 'master'
+
+
+class FakeUser(object):
+
+    @property
+    def author(self):
+        return self
+
+    @property
+    def name(self):
+        return 'Mr bean'
+
+    @property
+    def email(self):
+        return 'mr@bean.org'
+
+
+class FakeGithub(object):
+
+    def get_user(self, name):
+        return FakeUser()
+
+    def get_organization(self, name):
+        return self
+
+    def get_repo(self, name):
+        return self
+
+    def get_git_ref(self, name):
+        class HEAD(object):
+            @property
+            def object(self):
+                return self
+
+            @property
+            def sha(self):
+                return 'shaaaaa'
+
+            def edit(self, sha=None, force=False):
+                return
+
+        return HEAD()
+
+    def get_file_contents(self, name, sha):
+        return self
+
+    @property
+    def decoded_content(self):
+        return 'some text'
+
+    def get_git_commit(self, sha):
+        return self
+
+    @property
+    def tree(self):
+        return mock.MagicMock()
+
+    @property
+    def type(self):
+        return 'file'
+
+    def create_git_commit(self, one, two, three, four, five):
+        return mock.MagicMock()
+
+    def create_git_tree(self, one, two):
+        return mock.MagicMock()
+
+
+class MockRequest(object):
+
+    def __init__(self):
+        self._settings = {
+            'github': FakeGithub(),
+            'plone_versions': ['4.3', '5.1', ],
+        }
+
+    @property
+    def registry(self):
+        return self
+
+    @property
+    def settings(self):
+        return self._settings
+
+    def set_data(self, data, key):
+        with NamedTemporaryFile(delete=False) as tmp_file:
+            pickle_filename = tmp_file.name
+            with open(pickle_filename, 'w') as tmp_file_writer:
+                tmp_file_writer.write(pickle.dumps(data))
+
+        self._settings[key] = pickle_filename
+
+    def set_checkouts(self, data):
+        self.set_data(data, 'checkouts_file')
+
+    def set_sources(self, data):
+        self.set_data(data, 'sources_file')
+
+    def cleanup(self):
+        if os.path.exists(self._settings['checkouts_file']):
+            os.remove(self._settings['checkouts_file'])
+        if os.path.exists(self._settings['sources_file']):
+            os.remove(self._settings['sources_file'])
+
+
+class AddToCheckoutsSubscriberTest(unittest.TestCase):
+
+    def create_event(self, checkouts_data, sources_data, payload):
+        request = MockRequest()
+        request.set_checkouts(checkouts_data)
+        request.set_sources(sources_data)
+        event = MergedPullRequest(
+            pull_request=payload,
+            request=request,
+        )
+        return event
+
+    def test_buildout_coredev_merge(self):
+        event = self.create_event({}, {}, payload=PAYLOAD)
+
+        with LogCapture() as captured_data:
+            UpdateCoredevCheckouts(event)
+
+        event.request.cleanup()
+
+        self.assertEqual(
+            len(captured_data.records),
+            0,
+        )
+
+    def test_not_targeting_any_plone_version(self):
+        event = self.create_event({}, {}, payload=NO_PLONE_VERSION_PAYLOAD)
+
+        with LogCapture() as captured_data:
+            UpdateCoredevCheckouts(event)
+
+        event.request.cleanup()
+
+        self.assertEqual(
+            len(captured_data.records),
+            1,
+        )
+
+        self.assertIn(
+            'no plone coredev version tracks branch my-upstream-branch of '
+            'plone.uuid, checkouts.cfg not updated',
+            captured_data.records[0].msg,
+        )
+
+    def test_in_checkouts(self):
+        checkouts = {
+            '5.1': ['plone.uuid', ],
+        }
+        sources = {
+            ('plone/plone.uuid', 'master'): ['5.1', ],
+        }
+        event = self.create_event(
+            checkouts,
+            sources,
+            payload=PLONE_VERSION_PAYLOAD,
+        )
+
+        with LogCapture() as captured_data:
+            UpdateCoredevCheckouts(event)
+
+        event.request.cleanup()
+
+        self.assertEqual(
+            len(captured_data.records),
+            1,
+        )
+        self.assertIn(
+            'is already on checkouts.cfg of all plone versions that it '
+            'targets',
+            captured_data.records[0].msg,
+        )
+
+    def test_in_multiple_checkouts(self):
+        checkouts = {
+            '5.0': ['plone.uuid', ],
+            '5.1': ['plone.uuid', ],
+        }
+        sources = {
+            ('plone/plone.uuid', 'master'): ['5.1', '5.0', ],
+        }
+        event = self.create_event(
+            checkouts,
+            sources,
+            payload=PLONE_VERSION_PAYLOAD,
+        )
+
+        with LogCapture() as captured_data:
+            UpdateCoredevCheckouts(event)
+
+        event.request.cleanup()
+
+        self.assertEqual(
+            len(captured_data.records),
+            1,
+        )
+        self.assertIn(
+            'is already on checkouts.cfg of all plone versions that it '
+            'targets',
+            captured_data.records[0].msg,
+        )
+
+    def test_not_in_checkouts(self):
+        checkouts = {
+            '5.0': [],
+            '5.1': ['plone.uuid', ],
+        }
+        sources = {
+            ('plone/plone.uuid', 'master'): ['5.1', '5.0', ],
+        }
+        event = self.create_event(
+            checkouts,
+            sources,
+            payload=PLONE_VERSION_PAYLOAD,
+        )
+
+        with LogCapture() as captured_data:
+            UpdateCoredevCheckouts(event)
+
+        event.request.cleanup()
+
+        self.assertEqual(
+            len(captured_data.records),
+            1,
+        )
+        self.assertIn(
+            'add to checkouts.cfg of buildout.coredev 5.0',
+            captured_data.records[0].msg,
+        )
+
+    def test_not_in_multiple_checkouts(self):
+        checkouts = {
+            '4.3': [],
+            '5.0': [],
+            '5.1': ['plone.uuid', ],
+        }
+        sources = {
+            ('plone/plone.uuid', 'master'): ['5.1', '5.0', '4.3', ],
+        }
+        event = self.create_event(
+            checkouts,
+            sources,
+            payload=PLONE_VERSION_PAYLOAD,
+        )
+
+        with LogCapture() as captured_data:
+            UpdateCoredevCheckouts(event)
+
+        event.request.cleanup()
+
+        self.assertEqual(
+            len(captured_data.records),
+            2,
+        )
+        messages = sorted([
+            m.msg
+            for m in captured_data.records
+        ])
+        self.assertIn(
+            'add to checkouts.cfg of buildout.coredev 4.3',
+            messages[0],
+        )
+        self.assertIn(
+            'add to checkouts.cfg of buildout.coredev 5.0',
+            messages[1],
+        )

--- a/src/mr.roboto/src/mr/roboto/tests/test_pull_requests.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_pull_requests.py
@@ -29,6 +29,13 @@ UPDATED_PR_PAYLOAD['action'] = 'synchronize'
 UNKNOWN_PR_ACTION_PAYLOAD = copy.deepcopy(NEW_PR_PAYLOAD)
 UNKNOWN_PR_ACTION_PAYLOAD['action'] = 'unknown'
 
+CLOSED_NOT_MERGED_PR_ACTION_PAYLOAD = copy.deepcopy(NEW_PR_PAYLOAD)
+CLOSED_NOT_MERGED_PR_ACTION_PAYLOAD['action'] = 'closed'
+
+CLOSED_AND_MERGED_PR_ACTION_PAYLOAD = copy.deepcopy(NEW_PR_PAYLOAD)
+CLOSED_AND_MERGED_PR_ACTION_PAYLOAD['action'] = 'closed'
+CLOSED_AND_MERGED_PR_ACTION_PAYLOAD['pull_request']['merged'] = True
+
 
 def minimal_main(global_config, **settings):
     from github import Github
@@ -127,6 +134,30 @@ class RunCoreJobTest(unittest.TestCase, ):
         )
 
         self.assertIn(
-            'PR plone/mr.roboto#1: action "unknown" not handled',
+            'PR plone/mr.roboto#1: action "unknown" (merged: False) '
+            'not handled',
             captured_data.records[-1].msg
+        )
+
+    def test_closed_not_merged_pull_request_action(self):
+        with LogCapture() as captured_data:
+            self.call_view(CLOSED_NOT_MERGED_PR_ACTION_PAYLOAD)
+
+        self.assertEqual(
+            len(captured_data.records),
+            2
+        )
+
+        self.assertIn(
+            'PR plone/mr.roboto#1: action "closed" (merged: False) '
+            'not handled',
+            captured_data.records[-1].msg
+        )
+
+    def test_closed_and_merged_pull_request_action(self):
+        result = self.call_view(CLOSED_AND_MERGED_PR_ACTION_PAYLOAD)
+
+        self.assertIn(
+            'Handlers already took care of this pull request',
+            result.body,
         )

--- a/src/mr.roboto/src/mr/roboto/tests/test_subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_subscriber.py
@@ -51,7 +51,7 @@ class SubscribersTest(unittest.TestCase):
         mail = mock_mail.send_immediately.call_args[0][0]
         self.assertEqual(
             mail.subject,
-            'CHECKOUT ERROR plone/Products.CMFPlone master',
+            'POSSIBLE CHECKOUT ERROR plone/Products.CMFPlone master',
         )
         self.assertEqual(
             mail.sender,

--- a/src/mr.roboto/src/mr/roboto/views/pull_requests.py
+++ b/src/mr.roboto/src/mr/roboto/views/pull_requests.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 from cornice import Service
+from mr.roboto.events import MergedPullRequest
 from mr.roboto.events import NewPullRequest
 from mr.roboto.events import UpdatedPullRequest
 from mr.roboto.security import validate_github
@@ -47,6 +48,10 @@ def handle_pull_request(request):
     elif action == 'synchronize':
         request.registry.notify(
             UpdatedPullRequest(pull_request, request)
+        )
+    elif action == 'closed' and pull_request['merged']:
+        request.registry.notify(
+            MergedPullRequest(pull_request, request)
         )
     else:
         msg = 'PR {0}: action "{1}" not handled'.format(

--- a/src/mr.roboto/src/mr/roboto/views/pull_requests.py
+++ b/src/mr.roboto/src/mr/roboto/views/pull_requests.py
@@ -54,9 +54,10 @@ def handle_pull_request(request):
             MergedPullRequest(pull_request, request)
         )
     else:
-        msg = 'PR {0}: action "{1}" not handled'.format(
+        msg = 'PR {0}: action "{1}" (merged: {2}) not handled'.format(
             short_url,
             action,
+            pull_request['merged'],
         )
         logger.info(msg)
         return json.dumps({'message': msg, })


### PR DESCRIPTION
@tisto @mauritsvanrees is it ok to add the package that got a pull request merged on checkouts.cfg for **all** buildout.coredev branches which track the branch where the pull request was merged to?

Then we should clean them up whenever a release is done, right?

Fixes: https://github.com/plone/mr.roboto/issues/26