### PR TITLE
Encode commit message

### DIFF
--- a/src/mr.roboto/src/mr/roboto/tests/test_utils.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_utils.py
@@ -75,3 +75,20 @@ class TestGetInfoFromCommitTest(unittest.TestCase):
                 'Files changed:\nM CHANGES.rst\nM setup.py'
             )
         )
+
+    @mock.patch('requests.get')
+    def test_unicode_on_messages(self, mock_get):
+        mock_get.content = mock.Mock(return_value='diff data')
+        commit_data = COMMIT
+        commit_data['message'] = u'Höla què tal\n' \
+            u'Files changed:\nM CHÄNGES.rst\nM setup.py'
+        data = get_info_from_commit(commit_data)
+        self.assertEqual(
+            data['short_commit_msg'],
+            'Hla qu tal',
+        )
+        self.assertTrue(
+            data['full_commit_msg'].endswith(
+                'Files changed:\nM CHNGES.rst\nM setup.py'
+            )
+        )

--- a/src/mr.roboto/src/mr/roboto/utils.py
+++ b/src/mr.roboto/src/mr/roboto/utils.py
@@ -40,7 +40,8 @@ def get_info_from_commit(commit):
     files.extend('M {0}'.format(f) for f in commit['modified'])
     files.extend('D {0}'.format(f) for f in commit['removed'])
 
-    short_commit_msg = commit['message'].split('\n')[0][:60]
+    encoded_message = commit['message'].encode('ascii', 'ignore')
+    short_commit_msg = encoded_message.split('\n')[0][:60]
     reply_to = '{0} <{1}>'.format(
         commit['committer']['name'],
         commit['committer']['email']
@@ -50,7 +51,7 @@ def get_info_from_commit(commit):
         'diff': diff,
         'files': files,
         'short_commit_msg': short_commit_msg,
-        'full_commit_msg': commit['message'],
+        'full_commit_msg': encoded_message,
         'reply_to': reply_to,
         'sha': commit['id']
     }


### PR DESCRIPTION
This way, when used later on it does not break if the commit message has some non-ascii characters.