### PR TITLE
Add an extra blank line

### DIFF
--- a/src/mr.roboto/src/mr/roboto/templates/github_commit.pt
+++ b/src/mr.roboto/src/mr/roboto/templates/github_commit.pt
@@ -1,3 +1,4 @@
+
 Repository: ${push.repository.name}
 Branch: ${push.ref}
 Date: ${commit.timestamp}


### PR DESCRIPTION
On fake commits' commit message.

This way the first line (title) of the commit is just "[fc] Repository: REPO NAME"
and all the other details are in the body of the commit message.

Without that extra blank line everything was part of the title.