### PR TITLE
Accept changes in the news/ directory as valid changelog entry.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -371,6 +371,9 @@ class WarnNoChangelogEntry(PullRequestSubscriber):
         for diff_file in patch_data:
             if VALID_CHANGELOG_FILES.search(diff_file.path):
                 break
+            if diff_file.path.startswith('news/'):
+                # towncrier news snippet
+                break
         else:
             status = u'error'
             description = u'No entry found!'


### PR DESCRIPTION
Fixes issue #48.

Hard for me to try out. But I tested the basics in a Python prompt by using a `unidiff.PatchSet` of `last_commit.txt` from coredev 5.1, and it seems that this PR would indeed detect changes in the news directory.