### PR TITLE
Py versions per plone version

### DIFF
--- a/src/mr.roboto/src/mr/roboto/__init__.py
+++ b/src/mr.roboto/src/mr/roboto/__init__.py
@@ -32,14 +32,9 @@ def main(global_config, **settings):
         settings['plone_versions']
     )
 
-    # plone versions that need py3 support
-    config.registry.settings['plone_py3_versions'] = ast.literal_eval(
-        settings['plone_py3_versions']
-    )
-
-    # python versions
-    config.registry.settings['py3_versions'] = ast.literal_eval(
-        settings['py3_versions']
+    # dictionary the list of python versions (value) per plone version (key)
+    config.registry.settings['py_versions'] = ast.literal_eval(
+        settings['py_versions']
     )
 
     # github users

--- a/src/mr.roboto/src/mr/roboto/buildout.py
+++ b/src/mr.roboto/src/mr/roboto/buildout.py
@@ -50,7 +50,7 @@ class Source(object):
             match = PATH_RE.match(self.url)
             if match:
                 return match.groupdict()['path']
-        return None
+        return None  # pragma: no cover
 
 
 class SourcesFile(UserDict):
@@ -85,7 +85,7 @@ class CheckoutsFile(UserDict):
     @property
     def data(self):
         if self._data:
-            return self._data
+            return self._data  # pragma: no cover
         config = ConfigParser(interpolation=ExtendedInterpolation())
         with open(self.file_location) as f:
             config.read_file(f)
@@ -148,7 +148,7 @@ def get_sources_and_checkouts(request):
                 else:
                     sources_dict[key].append(plone_version)
             else:
-                logger.warning(f'Package {source} does not have a valid URL')
+                logger.warning(f'Package {source} does not have a valid URL')  # pragma: no cover
 
         checkouts_dict[plone_version] = []
         for checkout in buildout.checkouts.data:

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -198,10 +198,10 @@ class PullRequestSubscriber(object):
         return self._target_branch
 
     def run(self):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def log(self, msg, level='info'):
-        if level == 'warn':
+        if level == 'warn':  # pragma: no cover
             logger.warning(f'PR {self.short_url}: {msg}')
             return
         logger.info(f'PR {self.short_url}: {msg}')
@@ -522,7 +522,7 @@ class UpdateCoredevCheckouts(PullRequestSubscriber):
             while attempts < 5:
                 try:
                     self.make_commit(repo, version, user)
-                except GithubException:
+                except GithubException:  # pragma: no cover
                     attempts += 1
                     if attempts == 5:
                         self.log(
@@ -544,7 +544,7 @@ class UpdateCoredevCheckouts(PullRequestSubscriber):
         latest_commit = repo.get_git_commit(head_ref.object.sha)
         base_tree = latest_commit.tree
         mode = [t.mode for t in base_tree.tree if t.path == filename]
-        if mode:
+        if mode:  # pragma: no cover
             mode = mode[0]
         else:
             mode = '100644'

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -351,7 +351,7 @@ class WarnNoChangelogEntry(PullRequestSubscriber):
         for diff_file in patch_data:
             if VALID_CHANGELOG_FILES.search(diff_file.path):
                 break
-            if diff_file.path.startswith('news/'):
+            if 'news/' in diff_file.path:
                 # towncrier news snippet
                 break
         else:

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -385,20 +385,16 @@ class WarnTestsNeedToRun(PullRequestSubscriber):
         """Create waiting status for all pull request jobs that should be run
         before a pull request can be safely merged
         """
-        # This may return ["5.2", "6.0"].
         plone_versions = self._plone_versions_targeted()
-        # This WarnTestsNeedToRun check is for Python 2 only.
-        # The plone_versions setting in production.ini should contain only 2.7
-        plone_py2_versions = self.event.request.registry.settings['plone_versions']
+        python_versions = self.event.request.registry.settings['py_versions']
 
         # get the pull request last commit
         last_commit = self.get_pull_request_last_commit()
 
-        for version in plone_versions:
-            if version not in plone_py2_versions:
-                continue
-            self._create_commit_status(last_commit, version)
-            self.log(f'created pending status for plone {version}')
+        for plone_version in plone_versions:
+            for py_version in python_versions[plone_version]:
+                self._create_commit_status(last_commit, plone_version, py_version)
+                self.log(f'created pending status for plone {plone_version} on python {py_version}')
 
     def _plone_versions_targeted(self):
         if self.repo_name in IGNORE_NO_TEST_NEEDED:
@@ -423,38 +419,6 @@ class WarnTestsNeedToRun(PullRequestSubscriber):
             return []
 
         return plone_versions
-
-    def _create_commit_status(self, commit, version):
-        commit.create_status(
-            u'pending',
-            target_url=self.jenkins_pr_job_url.format(version),
-            description='Please run the job, click here --->',
-            context=self.status_context.format(version),
-        )
-
-
-@subscriber(NewPullRequest, UpdatedPullRequest)
-class WarnPy3TestsNeedToRun(WarnTestsNeedToRun):
-    def run(self):
-        """Create waiting status for pull requests that target a plone version
-        that targets python 3.
-        """
-        plone_py3_versions = self.event.request.registry.settings['plone_py3_versions']
-        plone_versions = self._plone_versions_targeted()
-
-        if not set(plone_py3_versions).intersection(plone_versions):
-            self.log('does not target a Plone version that targets Python 3, no py3 pull request job needed')
-            return
-
-        py3_tracked_versions = self.event.request.registry.settings['py3_versions']
-
-        # get the pull request and last commit
-        last_commit = self.get_pull_request_last_commit()
-
-        for plone_version in plone_py3_versions:
-            for py_version in py3_tracked_versions:
-                self._create_commit_status(last_commit, plone_version, py_version)
-                self.log(f'created pending status for plone {plone_version} on python {py_version}')
 
     def _create_commit_status(self, commit, plone_version, python_version):
         combination = f'{plone_version}-{python_version}'
@@ -626,14 +590,11 @@ class TriggerPullRequestJenkinsJobs(object):
 
     def _trigger_jobs(self, plone_versions):
         settings = self.event.request.registry.settings
-        py3_versions = settings['py3_versions']
-        plone_py3_versions = settings['plone_py3_versions']
+        python_versions = settings['py_versions']
 
-        for version in plone_versions:
-            self._create_job(version)
-            if version in plone_py3_versions:
-                for python in py3_versions:
-                    self._create_job(f'{version}-{python}')
+        for plone in plone_versions:
+            for python in python_versions[plone]:
+                self._create_job(f'{plone}-{python}')
 
     def _create_job(self, version):
         settings = self.event.request.registry.settings

--- a/src/mr.roboto/src/mr/roboto/tests/__init__.py
+++ b/src/mr.roboto/src/mr/roboto/tests/__init__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+
+def default_settings(github=None, parsed=True, override_settings=None):
+    plone = ['5.2', '6.0']
+    python = {'5.2': ['2.7', '3.6', ], '6.0': ['3.8', '3.9']}
+    github_users = ['mister-roboto', 'jenkins-plone-org', ]
+    if not parsed:
+        plone = str(plone)
+        python = str(python)
+        github_users = str(github_users)
+    data = {
+        'plone_versions': plone,
+        'py_versions': python,
+        'roboto_url': 'http://jenkins.plone.org/roboto',
+        'api_key': '1234567890',
+        'sources_file': 'sources.pickle',
+        'checkouts_file': 'checkouts.pickle',
+        'github_token': 'secret',
+        'jenkins_user_id': 'jenkins-plone-org',
+        'jenkins_user_token': 'some-random-token',
+        'jenkins_url': 'https://jenkins.plone.org',
+        'collective_repos': '',
+        'github': github,
+        'github_users': github_users,
+        'debug': 'True',
+    }
+    if override_settings:
+        data.update(override_settings)
+    return data
+
+
+def minimal_main(override_settings=None, scan_path=''):
+    from github import Github
+    from pyramid.config import Configurator
+
+    settings = default_settings(override_settings=override_settings)
+
+    config = Configurator(settings=settings)
+    config.include('cornice')
+
+    for key, value in settings.items():
+        config.registry.settings[key] = value
+
+    config.registry.settings['github_users'] = (
+        settings['jenkins_user_id'],
+        'mister-roboto',
+    )
+    config.registry.settings['github'] = Github(settings['github_token'])
+
+    config.scan(scan_path)
+    config.end()
+    return config.make_wsgi_app()

--- a/src/mr.roboto/src/mr/roboto/tests/test_changelog_entry.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_changelog_entry.py
@@ -51,6 +51,20 @@ index 2a20bdc..57ce05f 100644
  setup(
 """
 
+DIFF_WITH_NEWS_ENTRY = """
+diff --git a/src/mr.roboto/CHANGES.rst b/src/mr.roboto/news/1.bugfix
+index 2a20bdc..57ce05f 100644
+--- a/src/mr.roboto/news/1.bugfix
++++ b/src/mr.roboto/news/1.bugfix
+@@ -16,6 +16,7 @@
+     'pyramid_debugtoolbar',
+     'pytest',
+     'WebTest',
++    'testfixtures',
+ ]
+ setup(
+"""
+
 DIFF_WITH_CHANGELOG_ON_HISTORY_txt = """diff --git a/src/mr.roboto/HISTORY.rst b/src/mr.roboto/HISTORY.rst
 index 2a20bdc..57ce05f 100644
 --- a/src/mr.roboto/HISTORY.rst
@@ -118,6 +132,17 @@ class ChangeLogEntrySubscriberTest(unittest.TestCase):
     @mock.patch('requests.get')
     def test_with_change_log_file(self, m1):
         m1.return_value = MockDiff(DIFF_WITH_CHANGELOG)
+
+        event = NewPullRequest(pull_request=PAYLOAD, request=MockRequest())
+
+        with LogCapture() as captured_data:
+            WarnNoChangelogEntry(event)
+
+        self.assertIn('changelog entry: success', captured_data.records[-1].msg)
+
+    @mock.patch('requests.get')
+    def test_with_news_entry(self, m1):
+        m1.return_value = MockDiff(DIFF_WITH_NEWS_ENTRY)
 
         event = NewPullRequest(pull_request=PAYLOAD, request=MockRequest())
 

--- a/src/mr.roboto/src/mr/roboto/tests/test_config.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_config.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from mr.roboto import main
+from mr.roboto.tests import default_settings
 from webtest import TestApp as BaseApp
 
 import unittest
@@ -7,30 +8,15 @@ import unittest
 
 class ConfigurationTest(unittest.TestCase):
     def setUp(self):
-        settings = {
-            'plone_versions': '["4.3", "5.1"]',
-            'py3_versions': '["2.7", "3.6", ]',
-            'plone_py3_versions': '["5.2", ]',
-            'github_users': '["mister-roboto", "jenkins-plone-org", ]',
-            'roboto_url': 'http://mr.roboto.plone.org',
-            'api_key': '1234567890',
-            'sources_file': 'sources.pickle',
-            'checkouts_file': 'checkouts.pickle',
-            'github_token': 'secret',
-            'debug': 'True',
-        }
-        app = main({}, **settings)
+        app = main({}, **default_settings(parsed=False))
         self.roboto = BaseApp(app)
-        self.settings = self.roboto.app.registry.settings
+        self.settings = app.registry.settings
 
     def test_plone_versions(self):
-        self.assertEqual(self.settings['plone_versions'], ['4.3', '5.1'])
+        self.assertEqual(self.settings['plone_versions'], ['5.2', '6.0'])
 
-    def test_py3_versions(self):
-        self.assertEqual(self.settings['py3_versions'], ['2.7', '3.6'])
-
-    def test_plone_py3_versions(self):
-        self.assertEqual(self.settings['plone_py3_versions'], ['5.2', ])
+    def test_python_versions(self):
+        self.assertEqual(self.settings['py_versions'], {'5.2': ['2.7', '3.6'], '6.0': ['3.8', '3.9', ]})
 
     def test_github_users(self):
         self.assertEqual(
@@ -38,7 +24,7 @@ class ConfigurationTest(unittest.TestCase):
         )
 
     def test_roboto_url(self):
-        self.assertEqual(self.settings['roboto_url'], 'http://mr.roboto.plone.org')
+        self.assertEqual(self.settings['roboto_url'], 'http://jenkins.plone.org/roboto')
 
     def test_api_key(self):
         self.assertEqual(self.settings['api_key'], '1234567890')
@@ -55,8 +41,7 @@ class ConfigurationTest(unittest.TestCase):
     def test_no_debug(self):
         settings = {
             'plone_versions': '["4.3", "5.1"]',
-            'py3_versions': '["2.7", "3.6", ]',
-            'plone_py3_versions': '["5.2", ]',
+            'py_versions': '["2.7", "3.6", ]',
             'github_users': '["mister-roboto", "jenkins-plone-org", ]',
             'roboto_url': 'x',
             'api_key': 'x',

--- a/src/mr.roboto/src/mr/roboto/tests/test_pull_requests.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_pull_requests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from hashlib import sha1
+from mr.roboto.tests import minimal_main
 from testfixtures import LogCapture
 from webtest import TestApp as BaseApp
 
@@ -37,34 +38,12 @@ CLOSED_AND_MERGED_PR_ACTION_PAYLOAD['action'] = 'closed'
 CLOSED_AND_MERGED_PR_ACTION_PAYLOAD['pull_request']['merged'] = True
 
 
-def minimal_main(global_config, **settings):
-    from github import Github
-    from pyramid.config import Configurator
-
-    config = Configurator(settings=settings)
-    config.include('cornice')
-
-    config.registry.settings['plone_versions'] = settings['plone_versions']
-    config.registry.settings['roboto_url'] = settings['roboto_url']
-    config.registry.settings['api_key'] = settings['api_key']
-    config.registry.settings['github'] = Github(settings['github_token'])
-    config.scan('mr.roboto.views.pull_requests')
-    config.end()
-    return config.make_wsgi_app()
-
-
 class RunCoreJobTest(unittest.TestCase):
     def setUp(self):
-        self.settings = {
-            'plone_versions': ['4.3'],
-            'roboto_url': 'http://jenkins.plone.org/roboto',
-            'api_key': 'xyz1234mnop',
-            'sources_file': 'sources_pickle',
-            'checkouts_file': 'checkouts_pickle',
-            'github_token': 'x',
-        }
-        app = minimal_main({}, **self.settings)
+        settings = {}
+        app = minimal_main(settings, 'mr.roboto.views.pull_requests')
         self.roboto = BaseApp(app)
+        self.settings = app.registry.settings
 
     def prepare_data(self, payload):
         body = urllib.parse.urlencode({'payload': json.dumps(payload)})

--- a/src/mr.roboto/src/mr/roboto/tests/test_runhooks.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_runhooks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from github.GithubException import GithubException
 from mr.roboto import main
+from mr.roboto.tests import default_settings
 from webtest import TestApp as BaseApp
 
 import mock
@@ -36,21 +37,10 @@ class DummyGetRepos(object):
 
 class RunHooksTest(unittest.TestCase):
     def setUp(self):
-        self.settings = {
-            'plone_versions': '["4.3",]',
-            'py3_versions': '["2.7", "3.6", ]',
-            'plone_py3_versions': '["5.2", ]',
-            'github_users': '["mister-roboto", "jenkins-plone-org", ]',
-            'roboto_url': 'http://jenkins.plone.org/roboto',
-            'api_key': 'xyz1234mnop',
-            'sources_file': 'sources_pickle',
-            'checkouts_file': 'checkouts_pickle',
-            'github_token': 'x',
-            'collective_repos': '',
-            'jenkins_url': 'https://jenkins.plone.org',
-        }
-        app = main({}, **self.settings)
+        override_settings = {'debug': 'False'}
+        app = main({}, **default_settings(parsed=False, override_settings=override_settings))
         self.roboto = BaseApp(app)
+        self.settings = app.registry.settings
 
     def test_runhook_security(self):
         result = self.roboto.get('/run/githubcommithooks')

--- a/src/mr.roboto/src/mr/roboto/tests/test_simple_views.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_simple_views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from mr.roboto import main
 from mr.roboto.views.home import parse_log_line
+from mr.roboto.tests import default_settings
 from webtest import TestApp as BaseApp
 
 import mock
@@ -11,19 +12,9 @@ import unittest
 
 class SimpleViewsTest(unittest.TestCase):
     def setUp(self):
-        self.settings = {
-            'plone_versions': '["4.3",]',
-            'py3_versions': '["2.7", "3.6", ]',
-            'plone_py3_versions': '["5.2", ]',
-            'github_users': '["mister-roboto", "jenkins-plone-org", ]',
-            'roboto_url': 'http://jenkins.plone.org/roboto',
-            'api_key': 'z',
-            'sources_file': 'sources.pickle',
-            'checkouts_file': 'checkouts.pickle',
-            'github_token': 'x',
-        }
-        app = main({}, **self.settings)
+        app = main({}, **default_settings(parsed=False))
         self.roboto = BaseApp(app)
+        self.settings = app.registry.settings
 
     def clean_file(self, filename):
         try:

--- a/src/mr.roboto/src/mr/roboto/views/runcorejob.py
+++ b/src/mr.roboto/src/mr/roboto/views/runcorejob.py
@@ -33,7 +33,7 @@ class GMT1(datetime.tzinfo):
     def dst(self, dt):
         return datetime.timedelta(0)
 
-    def tzname(self, dt):
+    def tzname(self, dt):  # pragma: no cover
         return 'Europe/Catalunya'
 
 
@@ -220,7 +220,7 @@ def commit_on_plone_version(
             commit_to_coredev(
                 request, payload, plone_version, changeset, changeset_long, timestamp
             )
-        except GithubException:
+        except GithubException:  # pragma: no cover
             logger.warning(
                 'Got an exception while trying to commit, give it another try'
             )


### PR DESCRIPTION
With the test suite it does work. I simplified the code so that there is no difference between plone versions and plone on python 3 versions. As `python_versions` is a dictionary, one can just add `2.7` on `5.2` and that's it.

⚠️ Minor/major change though: the jobs on jenkins will need to be renamed only once this pull request gets deployed!