### PR TITLE
Insert buildout:directory in config.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/buildout.py
+++ b/src/mr.roboto/src/mr/roboto/buildout.py
@@ -7,6 +7,7 @@ from tempfile import mkdtemp
 
 import git
 import logging
+import os
 import pickle
 import re
 import shutil
@@ -66,6 +67,9 @@ class SourcesFile(UserDict):
         config.optionxform = str
         with open(self.file_location) as f:
             config.read_file(f)
+        # Insert buildout:directory, as workaround for
+        # https://github.com/plone/mr.roboto/issues/82
+        config["buildout"]["directory"] = os.getcwd()
         sources_dict = OrderedDict()
         for name, value in config['sources'].items():
             source = Source().create_from_string(value)


### PR DESCRIPTION
This is a workaround for issue https://github.com/plone/mr.roboto/issues/82
Should prevent this error with coredev 6.0 sources.cfg:

```
backports.configparser.InterpolationMissingOptionError:
Bad value substitution: option 'docs-classicui' in section 'sources' contains an interpolation key 'buildout:directory' which is not a valid option name.
Raw value: 'git ${remotes:plone}/documentation.git pushurl=${remotes:plone_push}/documentation.git egg=false branch=classic-ui path=${buildout:directory}/documentation/classic-ui'
```