### PR TITLE
docs(prs): Clarify automatic PR comment text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Python artifacts
+/.venv
+
 bin
 eggs
 .eggs
@@ -20,3 +23,6 @@ development.ini
 .plone.versioncheck.cache/
 .plone.versioncheck.tracked.json
 lib64
+
+# Variable, checkout-local data
+/var

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# mr.roboto development
+
+### Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-xeu -o pipefail -O inherit_errexit -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
+
+
+# Top-level targets
+
+.PHONY: all
+## Default target, build everything but don't run anything
+all: build
+
+.PHONY: build
+## Install the buildout
+build: ./.installed.cfg
+
+.PHONY: run
+## Run the web application development server
+run: ./development.ini build
+	./bin/pserve "$(<)" --reload
+
+.PHONY: test
+## Run the tests
+test: build
+# Run all checks but fail if any fail
+	exit_status=0
+	./bin/pytest || exit_status=$$?
+	./bin/code-analysis --return-status-codes || exit_status=$$?
+	./bin/versioncheck || exit_status=$$?
+	exit $$exit_status
+
+.PHONY: clean
+## Remove all build artifacts
+clean:
+	rm -rf "./.venv/" "./bin/" \
+	    "./eggs/" "./develop-eggs/" "./parts/" "./.installed.cfg"
+
+
+# Real targets
+
+ ./development.ini: ./development.ini.sample
+	if test -e "$(@)"
+	then
+# Template has updated but the local version exists, stop running
+	    diff -u "$(@)" "$(<)"
+	    false
+	else
+# Copy the template initially
+	    cp --backup=numbered -v "$(<)" "$(@)"
+	fi
+
+./.installed.cfg: ./.venv/bin/buildout ./src/mr.roboto/setup.py ./buildout.cfg
+	"$(<)"
+
+./.venv/bin/buildout: ./requirements.txt ./.venv/bin/pip
+	.venv/bin/pip install --upgrade --upgrade-strategy=eager "wheel" "pip"
+	.venv/bin/pip install -r "$(<)"
+
+./.venv/bin/pip:
+# Match ./.travis.yml
+	python3.7 -m "venv" "$(@:%/bin/pip=%/)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,5 @@ ignore = E501,  # black takes care of line length
     D202,  # black takes care of blank lines
     E203,  # black takes care of spaces around colon
 
+[tool:pytest]
+norecursedirs = .venv bin eggs develop-eggs parts include

--- a/src/mr.roboto/CONTRIBUTORS.rst
+++ b/src/mr.roboto/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@ Contributors
 
 Gil Forcada Codinachs - gil.gnome@gmail.com
 Ramon Navarro Bosch - ramon.nb@gmail.com
+Ross Patterson - me@rpatterson.net

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -628,16 +628,25 @@ class ExplainHowToTriggerJenkinsJobs(PullRequestSubscriber):
 
         user = self.pull_request['user']['login']
         msg = (
-            f'@{user} thanks for creating this Pull Request and help improve Plone!\n\n'
-            'To ensure that these changes do not break other parts of Plone, '
-            'the Plone test suite matrix needs to pass.\n\n'
-            'Whenever you feel that the pull request is ready to be tested, '
-            'either start all jenkins jobs pull requests by yourself, '
-            'or simply add a comment in this pull request stating:\n\n'
+            f'@{user} thanks for creating this Pull Request and helping to improve '
+            'Plone!\n'
+            '\n'
+            'TL;DR: Finish pushing changes, pass all other checks, '
+            'then paste a comment:\n'
             '```\n'
             '@jenkins-plone-org please run jobs\n'
-            '```\n\n'
-            'With this simple comment all the jobs will be started automatically.\n\n'
+            '```\n'
+            '\n'
+            'To ensure that these changes do not break other parts of Plone, the Plone '
+            'test suite matrix needs to pass, but it takes 30-60 min.  '
+            'Other CI checks are usually much faster and the Plone Jenkins resources '
+            'are limited, so when done pushing changes and all other checks pass '
+            'either [start all Jenkins PR jobs yourself]'
+            '(https://jenkinsploneorg.readthedocs.io/en/latest/'
+            'run-pull-request-jobs.html#run-a-pull-request-job), '
+            'or simply add the comment above in this PR to start all the jobs '
+            'automatically.\n'
+            '\n'
             'Happy hacking!'
         )
         self.g_issue.create_comment(body=msg)

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -612,7 +612,14 @@ class TriggerPullRequestJenkinsJobs(object):
 
 @subscriber(NewPullRequest)
 class ExplainHowToTriggerJenkinsJobs(PullRequestSubscriber):
+    """
+    The comment automatically added to new Plone project PRs.
+    """
+
     def run(self):
+        """
+        Add the comment when a new Plone project PR is created.
+        """
         plone_versions = plone_versions_targeted(
             self.repo_full_name, self.target_branch, self.event.request
         )


### PR DESCRIPTION
Clarify that usually contributors should get all other checks passing before running the
Plone Jenkins PR jobs and add a link to the Plone Jenkins docs.  Also fix some typos and
do some other editing for brevity and clarity.

Fixes #84

Also includes capturing some cleanup and local development build and set up I did along
the way.