### PR TITLE
Do not set path attribute

### DIFF
--- a/src/mr.roboto/src/mr/roboto/buildout.py
+++ b/src/mr.roboto/src/mr/roboto/buildout.py
@@ -34,7 +34,8 @@ class Source(object):
         for param in source_parts[2:]:
             if param is not None:
                 key, value = param.split('=')
-                setattr(self, key, value)
+                if key != 'path':
+                    setattr(self, key, value)
         if self.pushurl is not None:
             # I doubt this is needed, should be handled already with
             # param.split above.


### PR DESCRIPTION
`Source` class already has a `path` property, if trying to set one via `setattr` python raises an exception.

This happens on `buildout.coredev` branch 6.0 where there are some documentation related sources that have an extra `path` attribute on their definition.

This should fix #82 