### PR TITLE
Insert buildout:docs-directory when reading sources.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/buildout.py
+++ b/src/mr.roboto/src/mr/roboto/buildout.py
@@ -73,6 +73,9 @@ class SourcesFile(UserDict):
         # Insert buildout:directory, as workaround for
         # https://github.com/plone/mr.roboto/issues/82
         config["buildout"]["directory"] = os.getcwd()
+        # Same now for buildout:docs-directory, as workaround for
+        # https://github.com/plone/mr.roboto/issues/89
+        config["buildout"]["docs-directory"] = os.path.join(os.getcwd(), "docs")
         sources_dict = OrderedDict()
         for name, value in config['sources'].items():
             source = Source().create_from_string(value)


### PR DESCRIPTION
Workaround for https://github.com/plone/mr.roboto/issues/89