### PR TITLE
Use https instead of unauthenticated git protocol.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/buildout.py
+++ b/src/mr.roboto/src/mr/roboto/buildout.py
@@ -106,7 +106,7 @@ class CheckoutsFile(UserDict):
 
 
 class PloneCoreBuildout(object):
-    PLONE_COREDEV_LOCATION = 'git://github.com/plone/buildout.coredev.git'
+    PLONE_COREDEV_LOCATION = 'https://github.com/plone/buildout.coredev.git'
 
     def __init__(self, core_version=None):
         self.core_version = core_version

--- a/src/mr.roboto/src/mr/roboto/tests/test_buildout.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_buildout.py
@@ -12,7 +12,7 @@ import shutil
 import unittest
 
 
-git_source = 'git://github.com/plone/Products'
+git_source = 'https://github.com/plone/Products'
 ssh_source = 'git@github.com:plone/Products'
 SOURCES = """
 [sources]


### PR DESCRIPTION
Sample error:

```
Fetching upstream changes from git://github.com/plone/buildout.coredev.git
 > git --version # timeout=10
 > git --version # 'git version 2.17.1'
 > git fetch --no-tags --progress --depth=10 -- git://github.com/plone/buildout.coredev.git +refs/heads/*:refs/remotes/origin/* # timeout=10
ERROR: Error cloning remote repo 'origin'
hudson.plugins.git.GitException: Command "git fetch --no-tags --progress --depth=10 -- git://github.com/plone/buildout.coredev.git +refs/heads/*:refs/remotes/origin/*" returned status code 128:
stdout:
stderr: fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
```

This GitHub change was announced last year, and has been really changed this week.

See for example this PR job:
https://jenkins.plone.org/job/pull-request-6.0-3.7/1029/console

cc @gforcada @fredvd 