### PR TITLE
Ignore some packages in Jenkins-related tasks.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -51,6 +51,12 @@ IGNORE_NO_TEST_NEEDED = ('plone.releaser',)
 
 IGNORE_NO_AUTO_CHECKOUT = ('documentation',)
 
+# Ignore packages that have no influence on Jenkins.
+IGNORE_NO_JENKINS = (
+    'documentation',
+    'plone.recipe.zope2instance',
+)
+
 
 def mail_missing_checkout(mailer, who, repo, branch, pv, email):
     msg = Message(
@@ -447,7 +453,7 @@ class UpdateCoredevCheckouts(PullRequestSubscriber):
 
         if self.repo_name in IGNORE_NO_AUTO_CHECKOUT:
             return
-        
+
         plone_versions = plone_versions_targeted(
             self.repo_full_name, self.target_branch, self.event.request
         )
@@ -625,6 +631,9 @@ class ExplainHowToTriggerJenkinsJobs(PullRequestSubscriber):
         """
         Add the comment when a new Plone project PR is created.
         """
+        if self.repo_name in IGNORE_NO_JENKINS:
+            return
+
         plone_versions = plone_versions_targeted(
             self.repo_full_name, self.target_branch, self.event.request
         )

--- a/src/mr.roboto/src/mr/roboto/views/runcorejob.py
+++ b/src/mr.roboto/src/mr/roboto/views/runcorejob.py
@@ -8,6 +8,7 @@ from mr.roboto.buildout import get_sources_and_checkouts
 from mr.roboto.events import CommitAndMissingCheckout
 from mr.roboto.events import NewCoreDevPush
 from mr.roboto.security import validate_github
+from mr.roboto.subscribers import IGNORE_NO_JENKINS
 from mr.roboto.utils import get_info_from_commit
 from mr.roboto.utils import get_pickled_data
 from mr.roboto.utils import plone_versions_targeted
@@ -157,8 +158,22 @@ def run_function_core_tests(request):
 
         return json.dumps({'message': 'Thanks! Commit to coredev, nothing to do'})
 
+    # If it is a push to a package we ignore,
+    # update sources and checkouts and quit
+    if repo_name in IGNORE_NO_JENKINS:
+        logger.info('Commit: repo in IGNORE_NO_JENKINS - do nothing')
+        if source_or_checkout:
+            get_sources_and_checkouts(request)
+
+        return json.dumps(
+            {
+                'message':
+                'Thanks! Commit to package that is not tested on Jenkins, nothing to do',
+            }
+        )
+
     ##
-    # It's not a commit to coredev repo
+    # It's not a commit to coredev or an ignored repo
     ##
 
     # if it's a skip commit, log and done


### PR DESCRIPTION
Changes in the documentation and plone.recipe.zope2instance repos have no influence on Jenkins.
So for these repos:

- In a PR do not add the comment on how to run Jenkins tests.
- On changes, do not make a fake commit in coredev to trigger the Jenkins jobs.