### PR TITLE
No changelog verifier needed for mockup.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -32,6 +32,7 @@ VALID_CHANGELOG_FILES = re.compile(r'(CHANGES|HISTORY|CHANGELOG).(txt|rst|md)$')
 
 IGNORE_NO_CHANGELOG = (
     'documentation',
+    'mockup',
     'mr.roboto',
     'jenkins.plone.org',
     'plone.jenkins_node',


### PR DESCRIPTION
It uses release-it to create a changelog out of the commit messages.
See small discussion in Discord in the classic-ui channel.