### PR TITLE
feat: allow re-creating hooks for one single repo

### DIFF
--- a/src/mr.roboto/src/mr/roboto/templates/home.pt
+++ b/src/mr.roboto/src/mr/roboto/templates/home.pt
@@ -58,6 +58,10 @@
       <a href="${info.roboto_url}/run/githubcommithooks?token=XXXXX">Re-create GitHub commit hooks</a>
       <em class="alert">Token needed</em>
     </li>
+    <li>
+      <a href="${info.roboto_url}/run/githubcommithooks?token=XXXXX&repo=plone.batching">Re-create GitHub commit hooks (on one single repo)</a>
+      <em class="alert">Token needed</em>
+    </li>
   </ul>
 
 </body>


### PR DESCRIPTION
Much more useful than to running on all plone and some collective repos when a new repository is added on Plone organization.

Closes #73 