### PR TITLE
feat: do not require changelog

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -27,7 +27,9 @@ import requests
 
 logger = logging.getLogger('mr.roboto')
 
-VALID_CHANGELOG_FILES = re.compile(r'(CHANGES|HISTORY|CHANGELOG).(txt|rst|md)$')
+VALID_CHANGELOG_FILES = re.compile(
+    r'(.pre-commit-config|CHANGES|HISTORY|CHANGELOG).(txt|rst|md|yaml)$'
+)
 
 IGNORE_NO_CHANGELOG = (
     'documentation',


### PR DESCRIPTION
On PRs that modify the pre-commit configuration file.

They will be either be done via `plone/meta` configuration that already creates a news entry, or via `pre-commit.ci` service itself.

This way the missing valid changelog entry will not be required 👍🏾 

Closes #111 