### PR TITLE
dependabot has a new name

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -50,6 +50,7 @@ IGNORE_NO_AGREEMENT = ('icalendar', 'planet.plone.org', 'documentation', 'traini
 IGNORE_USER_NO_AGREEMENT = (
     'web-flow',
     'dependabot',
+    'dependabot[bot]',
     'pre-commit-ci[bot]',
 )
 


### PR DESCRIPTION
As seen on https://github.com/plone/plone.app.mosaic/pull/532 for example.

We need to ignore that user as well to request the contributor agreement.