### PR TITLE
Add `.github` repo to IGNORE_NO_CHANGELOG

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -32,6 +32,7 @@ VALID_CHANGELOG_FILES = re.compile(
 )
 
 IGNORE_NO_CHANGELOG = (
+    '.github',
     'documentation',
     'mockup',
     'mr.roboto',


### PR DESCRIPTION
It is not released per se, and we can see what changed in the git history.