### PR TITLE
feat: skip jenkins jobs for plone.versioncheck

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -57,7 +57,7 @@ IGNORE_USER_NO_AGREEMENT = (
     'pre-commit-ci[bot]',
 )
 
-IGNORE_NO_TEST_NEEDED = ('plone.releaser',)
+IGNORE_NO_TEST_NEEDED = ('plone.releaser', 'plone.versioncheck')
 
 IGNORE_NO_AUTO_CHECKOUT = ('documentation',)
 


### PR DESCRIPTION
As it's an auxiliary tool rather than code that runs within Plone.