### PR TITLE
icalendar: only run the changelog test.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -77,6 +77,7 @@ IGNORE_NO_AUTO_CHECKOUT = (
 IGNORE_NO_JENKINS = (
     'documentation',
     'icalendar',
+    'plone.recipe.zeoserver',
     'plone.recipe.zope2instance',
 )
 

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -33,37 +33,50 @@ VALID_CHANGELOG_FILES = re.compile(
 
 IGNORE_NO_CHANGELOG = (
     '.github',
+    'buildout.coredev',
     'documentation',
+    'jenkins.plone.org',
     'mockup',
     'mr.roboto',
-    'jenkins.plone.org',
-    'plone.jenkins_node',
-    'plone.jenkins_server',
-    'buildout.coredev',
-    'ploneorg.core',
-    'ploneorg.theme',
     'planet.plone.org',
-    'training',
     'plone-backend',
     'plone-frontend',
+    'plone.jenkins_node',
+    'plone.jenkins_server',
+    'ploneorg.core',
+    'ploneorg.theme',
+    'training',
 )
 
-IGNORE_NO_AGREEMENT = ('icalendar', 'planet.plone.org', 'documentation', 'training')
+IGNORE_NO_AGREEMENT = (
+    'documentation',
+    'icalendar',
+    'planet.plone.org',
+    'training',
+)
 
 IGNORE_USER_NO_AGREEMENT = (
-    'web-flow',
     'dependabot',
     'dependabot[bot]',
     'pre-commit-ci[bot]',
+    'web-flow',
 )
 
-IGNORE_NO_TEST_NEEDED = ('plone.releaser', 'plone.versioncheck')
+IGNORE_NO_TEST_NEEDED = (
+    'icalendar',
+    'plone.releaser',
+    'plone.versioncheck',
+)
 
-IGNORE_NO_AUTO_CHECKOUT = ('documentation',)
+IGNORE_NO_AUTO_CHECKOUT = (
+    'documentation',
+    'icalendar',
+)
 
 # Ignore packages that have no influence on Jenkins.
 IGNORE_NO_JENKINS = (
     'documentation',
+    'icalendar',
     'plone.recipe.zope2instance',
 )
 

--- a/src/mr.roboto/src/mr/roboto/views/runhooks.py
+++ b/src/mr.roboto/src/mr/roboto/views/runhooks.py
@@ -48,7 +48,10 @@ def create_github_post_commit_hooks_view(request):
         try:
             repo = github.get_organization('plone').get_repo(one_repo)
         except UnknownObjectException:
-            return json.dumps({'message': f'Repository {one_repo} not found'})
+            try:
+                repo = github.get_organization('collective').get_repo(one_repo)
+            except UnknownObjectException:
+                return json.dumps({'message': f'Repository {one_repo} not found'})
         messages.append(update_hooks_on_repo(repo, roboto_hooks, request))
         return json.dumps(messages)
 


### PR DESCRIPTION
See https://github.com/collective/icalendar/pull/514#issuecomment-1506108571 and following comments. From a Plone core development perspective, `icalendar` is a third party package since a while. It is used a lot outside of Plone, and is taken care of by people who are not core Plone developers.

The `plone.app.event` tests are run on every PR of this package, see [yaml file](https://github.com/collective/icalendar/blob/v5.0.5/.github/workflows/tests.yml#L26) and [`tox.ini`](https://github.com/collective/icalendar/blob/v5.0.5/tox.ini#L27). I keep tabs on new versions, and manually update its version in `buildout.coredev`. So nothing is needed on Jenkins, so `mr.roboto` does not need to do anything.  I have removed the roboto hooks in the settings of the `icalendar` repo.

But: checking for a changelog entry is still wanted.  That is where this PR comes in:

1. Add `icalendar` to all ignore lists, except for the required changelog.  (Also sort them alphabetically.)
2. Fix the `githubcommithooks` endpoint to look for a single repo in the collective if it is not in Plone.

With this in place, I can enable the hooks again for this single repo, and only the changelog entry would be checked.