### PR TITLE
Add missing packages to run mr.roboto

### DIFF
--- a/requirements-app.in
+++ b/requirements-app.in
@@ -5,3 +5,5 @@ pyramid_chameleon
 pyramid_mailer
 supervisor
 unidiff
+waitress
+Paste

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -28,6 +28,8 @@ hupper==1.12
     # via pyramid
 idna==3.4
     # via requests
+paste==3.5.3
+    # via -r requirements-app.in
 pastedeploy==3.0.1
     # via plaster-pastedeploy
 plaster==1.1.2
@@ -57,6 +59,8 @@ repoze-sendmail==4.4.1
     # via pyramid-mailer
 requests==2.30.0
     # via pygithub
+six==1.16.0
+    # via paste
 smmap==5.0.0
     # via gitdb
 supervisor==4.2.5
@@ -75,6 +79,8 @@ venusian==3.0.0
     # via
     #   cornice
     #   pyramid
+waitress==2.1.2
+    # via -r requirements-app.in
 webob==1.8.7
     # via pyramid
 wrapt==1.15.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -91,6 +91,8 @@ packaging==23.1
     # via
     #   black
     #   pytest
+paste==3.5.3
+    # via -r requirements-app.in
 pastedeploy==3.0.1
     # via plaster-pastedeploy
 pathspec==0.11.1
@@ -144,6 +146,8 @@ requests==2.30.0
     # via
     #   coveralls
     #   pygithub
+six==1.16.0
+    # via paste
 smmap==5.0.0
     # via gitdb
 soupsieve==2.4.1
@@ -167,7 +171,9 @@ venusian==3.0.0
     #   cornice
     #   pyramid
 waitress==2.1.2
-    # via webtest
+    # via
+    #   -r requirements-app.in
+    #   webtest
 webob==1.8.7
     # via
     #   pyramid


### PR DESCRIPTION
Now to run `mr.roboto` locally one only has to:

```shell
python3.11 -m venv .
. bin/activate
pip install pip-tools
pip-sync requirements-app.txt
pip install -e src/mr.roboto
cp development.ini.sample development.ini
./bin/pserve development.ini
```

We are one step closer to remove `buildout` from the equation and deploy and update dependencies much more easily and reliable 🍀 