### PR TITLE
Update hooks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 - Play with GitHub workflows.
   [gforcada]
 
+- The web hook that call directly to jenkins is only meant for `buildout.coredev`.
+  Ensure that all other repositories do not get it.
+  [gforcada]
+
 ## 1.0.1
 
 - Add GHA to run the test suite and gather coverage info.

--- a/src/mr.roboto/src/mr/roboto/views/runhooks.py
+++ b/src/mr.roboto/src/mr/roboto/views/runhooks.py
@@ -27,7 +27,6 @@ def create_github_post_commit_hooks_view(request):
     collective organizations and creates them anew.
     """
     github = request.registry.settings["github"]
-    jenkins_url = request.registry.settings["jenkins_url"]
     roboto_url = request.registry.settings["roboto_url"]
 
     # hooks URL
@@ -36,7 +35,6 @@ def create_github_post_commit_hooks_view(request):
         Hook(f"{roboto_url}/run/corecommit", ["push"]),
         Hook(f"{roboto_url}/run/pull-request", ["pull_request"]),
         Hook(f"{roboto_url}/run/comment", ["issue_comment"]),
-        Hook(f"{jenkins_url}/github-webhook/", ["*"]),
     ]
 
     messages = []
@@ -102,6 +100,14 @@ def update_hooks_on_repo(repo=None, new_hooks=None, request=None):
                     "secret": request.registry.settings["api_key"],
                 }
                 repo.create_hook("web", config, hook.events, True)
+            if repo.name == "buildout.coredev":
+                jenkins_url = request.registry.settings["jenkins_url"]
+                config = {
+                    "url": f"{jenkins_url}/github-webhook/",
+                    "secret": request.registry.settings["api_key"],
+                }
+                repo.create_hook("web", config, ["*"], True)
+
     except GithubException:
         logger.exception(f"Error creating hook on {repo.name}")
 


### PR DESCRIPTION
On each GitHub repository we have a few web hooks that call mr.roboto,
but one of them is talking directly to jenkins.

That one is actually only meant for buildout.coredev, to trigger the
main jenkins jobs on any change there. We don't want that to happen for
any other repository, otherwise the queue would grow out of bounds.

This PR ensures that whenever web hooks are re-created on GitHub, only
the web hooks meant for each repository are added, and skips the one
meant for buildout.coredev, which is added only for buildout.coredev.