### PR TITLE
Fix log parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## (unreleased)
 
-- _nothing_
+- Fix log parsing.
+  [gforcada]
 
 ## 1.0.2 (2023-05-28)
 

--- a/src/mr.roboto/src/mr/roboto/tests/test_simple_views.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_simple_views.py
@@ -137,7 +137,7 @@ class SimpleViewsTest(unittest.TestCase):
 
     def test_parse_log_line_format_commit(self):
         msg = parse_log_line(
-            "2013-12-12 22:34 INFO [mr.roboto][lala] "
+            "2013-12-12 22:34 INFO [mr.roboto][waitress-2] "
             "Commit: on plone/ploneorg.core master "
             "fcbc0f2764f84a027766d96493ea0d40823f7ef1"
         )

--- a/src/mr.roboto/src/mr/roboto/views/home.py
+++ b/src/mr.roboto/src/mr/roboto/views/home.py
@@ -14,7 +14,7 @@ LOG_LINE_RE = re.compile(
     r"([\d\-\s:,]+)"  # timestamp
     r"(\w+)"  # log level
     r"\s+"  # space
-    r"\[[\w\.]+\]\[\w+\]"  # logger name ([mr.roboto][waitress]
+    r"\[[\w\d\.\-]+\]\[[\w\d\.\-]+\]"  # logger name ([mr.roboto][waitress]
     r"(.+)"  # message
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,14 +27,14 @@ commands =
 skip_install = true
 deps =
     -r requirements-dev.txt
+    -e {toxinidir}/src/mr.roboto
 commands =
-    pip install -e {toxinidir}/src/mr.roboto
     pytest src
 
 [testenv:coverage]
 skip_install = true
 deps =
     -r requirements-dev.txt
+    -e {toxinidir}/src/mr.roboto
 commands =
-    pip install -e {toxinidir}/src/mr.roboto
     pytest src --cov --cov-report term-missing

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     -r requirements-dev.txt
     -e {toxinidir}/src/mr.roboto
 commands =
-    pytest src
+    pytest src {posargs}
 
 [testenv:coverage]
 skip_install = true


### PR DESCRIPTION
Since the buildout removal and the upgrade to python 3.11 the log format
is slightly different.