### PR TITLE
feat: skip coredev commits on request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## (unreleased)
 
-- _nothing_
+- Do not update `buildout.coredev` when a PR is merged
+  if the commit message has `[ci-skip]` or `[ci skip]` on it.
+  [gforcada]
 
 ## 1.1.2 (2023-05-30)
 

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -8,6 +8,7 @@ from mr.roboto.events import MergedPullRequest
 from mr.roboto.events import NewPullRequest
 from mr.roboto.events import UpdatedPullRequest
 from mr.roboto.utils import get_pickled_data
+from mr.roboto.utils import is_skip_commit_message
 from mr.roboto.utils import plone_versions_targeted
 from mr.roboto.utils import shorten_comment_url
 from mr.roboto.utils import shorten_pull_request_url
@@ -403,6 +404,10 @@ class UpdateCoredevCheckouts(PullRequestSubscriber):
             )
             return
 
+        if self.is_skip_commit():
+            self.log("Commit had a skip CI mark. No commit is done in buildout.coredev")
+            return
+
         plone_versions = plone_versions_targeted(
             self.repo_full_name, self.target_branch, self.event.request
         )
@@ -429,6 +434,11 @@ class UpdateCoredevCheckouts(PullRequestSubscriber):
             return
 
         self.add_pacakge_to_checkouts(not_in_checkouts)
+
+    def is_skip_commit(self):
+        last_commit = self.get_pull_request_last_commit()
+        commit_msg = last_commit.message
+        return is_skip_commit_message(commit_msg)
 
     def add_pacakge_to_checkouts(self, versions):
         """Add package to checkouts.cfg on buildout.coredev plone version"""

--- a/src/mr.roboto/src/mr/roboto/tests/test_add_to_checkouts.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_add_to_checkouts.py
@@ -41,6 +41,9 @@ PLONE_VERSION_PAYLOAD["base"]["ref"] = "master"
 
 
 class FakeGithub:
+    def __init__(self, commit_msg):
+        self.message = commit_msg
+
     def get_organization(self, name):
         return self
 
@@ -114,8 +117,11 @@ class FakeGithub:
 
 
 class MockRequest:
-    def __init__(self):
-        self._settings = {"github": FakeGithub(), "plone_versions": ["4.3", "5.1"]}
+    def __init__(self, commit_msg):
+        self._settings = {
+            "github": FakeGithub(commit_msg),
+            "plone_versions": ["4.3", "5.1"],
+        }
 
     @property
     def registry(self):
@@ -146,8 +152,8 @@ class MockRequest:
             os.remove(self._settings["sources_file"])
 
 
-def create_event(checkouts_data, sources_data, payload):
-    request = MockRequest()
+def create_event(checkouts_data, sources_data, payload, commit_msg=""):
+    request = MockRequest(commit_msg)
     request.set_checkouts(checkouts_data)
     request.set_sources(sources_data)
     event = MergedPullRequest(pull_request=payload, request=request)
@@ -239,5 +245,25 @@ def test_no_pr_commit_for_pre_commit_ci(caplog):
     assert len(caplog.records) == 1
     assert (
         "no commits on buildout.coredev as user pre-commit-ci[bot] is ignored"
+        in caplog.records[0].msg
+    )
+
+
+def test_skip_coredev_commit(caplog):
+    checkouts = {"4.3": [], "5.0": [], "5.1": ["plone.uuid"]}
+    sources = {("plone/plone.uuid", "master"): ["5.1", "5.0", "4.3"]}
+    event = create_event(
+        checkouts,
+        sources,
+        payload=PLONE_VERSION_PAYLOAD,
+        commit_msg="Skip with [ci-skip]",
+    )
+    caplog.set_level(logging.INFO)
+    UpdateCoredevCheckouts(event)
+    event.request.cleanup()
+
+    assert len(caplog.records) == 1
+    assert (
+        "Commit had a skip CI mark. No commit is done in buildout.coredev"
         in caplog.records[0].msg
     )

--- a/src/mr.roboto/src/mr/roboto/tests/test_utils.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_utils.py
@@ -1,8 +1,10 @@
 from mr.roboto.utils import get_info_from_commit
+from mr.roboto.utils import is_skip_commit_message
 from mr.roboto.utils import shorten_comment_url
 from mr.roboto.utils import shorten_pull_request_url
 from unittest import mock
 
+import pytest
 import unittest
 
 
@@ -90,3 +92,20 @@ class TestGetInfoFromCommitTest(unittest.TestCase):
                 "Files changed:\nM CHANGES.rst\nM setup.py"
             )
         )
+
+
+@pytest.mark.parametrize(
+    "message,expect",
+    (
+        ("random message", False),
+        ("please skip me", False),
+        ("please skip me, really [ci skip]", True),
+        ("please skip me, really [ci-skip]", True),
+        ("please skip me\n next lines [ci-skip]", True),
+        ("please skip me\n next lines [ci skip]", True),
+        ("please skip me\n next lines [ci skip] extra text", True),
+        ("please skip[ci skip]extra", True),
+    ),
+)
+def test_skip_commit_message(message, expect):
+    assert is_skip_commit_message(message) is expect

--- a/src/mr.roboto/src/mr/roboto/utils.py
+++ b/src/mr.roboto/src/mr/roboto/utils.py
@@ -71,3 +71,12 @@ def get_info_from_commit(commit):
         "reply_to": reply_to,
         "sha": commit["id"],
     }
+
+
+def is_skip_commit_message(message):
+    """Check if the commit message has a mark to CI skip mark"""
+    if "[ci-skip]" in message:
+        return True
+    if "[ci skip]" in message:
+        return True
+    return False

--- a/src/mr.roboto/src/mr/roboto/views/runcorejob.py
+++ b/src/mr.roboto/src/mr/roboto/views/runcorejob.py
@@ -7,6 +7,7 @@ from mr.roboto.buildout import get_sources_and_checkouts
 from mr.roboto.security import validate_github
 from mr.roboto.subscriber import IGNORE_NO_JENKINS
 from mr.roboto.utils import get_info_from_commit
+from mr.roboto.utils import is_skip_commit_message
 from mr.roboto.utils import plone_versions_targeted
 
 import datetime
@@ -92,9 +93,7 @@ def get_info(payload, repo, branch):
 
         if "[fc]" in commit_data["short_commit_msg"]:
             fake = True
-        if "[ci skip]" in commit_data["full_commit_msg"]:
-            skip = True
-        if "[ci-skip]" in commit_data["full_commit_msg"]:
+        if is_skip_commit_message(commit_data["full_commit_msg"]):
             skip = True
         if "sources.cfg" in files or "checkouts.cfg" in files:
             source_or_checkout = True


### PR DESCRIPTION
If a PR is merged and the commit message has a `[ci-skip]` text mark on it, then do not create a commit on buildout.coredev nor add the package where the PR got merged into `checkouts.cfg`.