### PR TITLE
Do not add Jenkins comment for plone.releaser PRs.

### DIFF
--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -70,12 +70,10 @@ IGNORE_NO_AUTO_CHECKOUT = (
 )
 
 # Ignore packages that have no influence on Jenkins.
-IGNORE_NO_JENKINS = (
+IGNORE_NO_JENKINS = IGNORE_NO_TEST_NEEDED + (
     "documentation",
-    "icalendar",
     "plone.recipe.zeoserver",
     "plone.recipe.zope2instance",
-    "plone.releaser",
 )
 
 # Authors that will not trigger a commit on buildout.coredev

--- a/src/mr.roboto/src/mr/roboto/subscriber.py
+++ b/src/mr.roboto/src/mr/roboto/subscriber.py
@@ -75,6 +75,7 @@ IGNORE_NO_JENKINS = (
     "icalendar",
     "plone.recipe.zeoserver",
     "plone.recipe.zope2instance",
+    "plone.releaser",
 )
 
 # Authors that will not trigger a commit on buildout.coredev

--- a/src/mr.roboto/src/mr/roboto/tests/test_warn_pull_request_jobs.py
+++ b/src/mr.roboto/src/mr/roboto/tests/test_warn_pull_request_jobs.py
@@ -145,4 +145,7 @@ def test_ignored(caplog):
     event.request.cleanup_sources()
 
     assert len(caplog.records) == 1
-    assert "skip adding test warnings, repo ignored" in caplog.records[0].msg
+    assert (
+        "Not adding pending Jenkins checks: plone.releaser ignored."
+        in caplog.records[0].msg
+    )


### PR DESCRIPTION
We already have it in the `IGNORE_NO_TEST_NEEDED`, but the [comment asking to trigger Jenkins jobs is still added](https://github.com/plone/plone.releaser/pull/76#issuecomment-2343020247).

Actually, if a package is in `IGNORE_NO_TEST_NEEDED`, then even if you would trigger Jenkins jobs, nothing would happen, if I follow the code correctly.  Indeed, I added that comment for triggering the jobs, but the robots log says:

> INFO COMMENT [plone/plone.releaser#76-2343059679](https://github.com/plone/plone.releaser/pull/76#issuecomment-2343059679): skip triggering jenkins jobs, repo is ignored

So let me add another commit to this PR to add the `IGNORE_NO_TEST_NEEDED` packages to `IGNORE_NO_JENKINS`.